### PR TITLE
Clear spell list on a successful add

### DIFF
--- a/html/dnd/dicecloudtools/spellbook.js
+++ b/html/dnd/dicecloudtools/spellbook.js
@@ -124,6 +124,8 @@ submitForm = function () {
                 <span aria-hidden="true">&times;</span>
               </button>
             </div>`
+            spellsToAdd.length = 0; // Clear the array including all of its references
+            updateToAddList();
             } else {
                 alert = `<div class="alert alert-danger alert-dismissible fade show" role="alert">
               Failed to insert: ${data.error}


### PR DESCRIPTION
Clear the list of spells to be added once they request has been successfully completed. Prevents you from adding the same spells more than once, and removes the need to refresh the page to clear your spell list when adding things to the same character in multiple bursts (like when manually leveling up).